### PR TITLE
Upgrade to Spring Boot 3 and add MongoDB library sample

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use Maven to build the project
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+RUN mvn -q dependency:go-offline
+COPY src ./src
+RUN mvn -q package -DskipTests
+
+# Runtime image
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/*.war app.war
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.war"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # spring-sample
-Spring boot sample code
-Test project for CI/CD
+
+This project demonstrates a simple Spring Boot application packaged as a WAR file. It now targets Spring Boot 3 and Java 21 and includes a small example of a digital book library backed by MongoDB.
+
+## Running
+
+Configure a MongoDB instance (default `mongodb://localhost:27017/bookdb`) or adjust `application.properties`. Build and run the application using Maven:
+
+```bash
+mvn spring-boot:run
+```
+
+The REST endpoints for managing books are exposed under `/books`.
+
+## Docker
+
+You can also run the application with a local MongoDB using Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+This exposes the application on port `8080` and MongoDB on `27017`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  mongo:
+    image: mongo:7
+    restart: always
+    ports:
+      - "27017:27017"
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongo
+    environment:
+      SPRING_DATA_MONGODB_URI: mongodb://mongo:27017/bookdb

--- a/pom.xml
+++ b/pom.xml
@@ -1,94 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<!-- Your own application should inherit from spring-boot-starter-parent -->
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-samples</artifactId>
-		<version>${revision}</version>
-	</parent>
-	<artifactId>spring-boot-sample-war</artifactId>
-	<packaging>war</packaging>
-	<name>Spring Boot War Sample</name>
-	<description>Spring Boot War Sample</description>
-	<properties>
-		<main.basedir>${basedir}/../..</main.basedir>
-		<m2eclipse.wtp.contextRoot>/</m2eclipse.wtp.contextRoot>
-	</properties>
-	<dependencies>
-		<!-- Compile -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-		<dependency>
-			<!-- To build an executable war use one of the profiles below -->
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-tomcat</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<!-- Provided -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<!-- Test -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-	<profiles>
-		<profile>
-			<id>tomcat</id>
-			<dependencies>
-				<dependency>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-tomcat</artifactId>
-					<scope>provided</scope>
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
-			<id>jetty</id>
-			<dependencies>
-				<dependency>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-jetty</artifactId>
-					<scope>provided</scope>
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
-			<id>undertow</id>
-			<dependencies>
-				<dependency>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-undertow</artifactId>
-					<scope>provided</scope>
-				</dependency>
-			</dependencies>
-		</profile>
-	</profiles>
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>spring-boot-sample-war</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>Spring Boot Sample</name>
+    <description>Spring Boot sample with MongoDB library</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/sample/library/Book.java
+++ b/src/main/java/sample/library/Book.java
@@ -1,0 +1,50 @@
+package sample.library;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "books")
+public class Book {
+    @Id
+    private String id;
+    private String title;
+    private String author;
+    private String description;
+
+    public Book() {
+    }
+
+    public Book(String title, String author, String description) {
+        this.title = title;
+        this.author = author;
+        this.description = description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/sample/library/BookController.java
+++ b/src/main/java/sample/library/BookController.java
@@ -1,0 +1,47 @@
+package sample.library;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/books")
+public class BookController {
+    private final BookRepository repository;
+
+    public BookController(BookRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<Book> list() {
+        return repository.findAll();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Book create(@RequestBody Book book) {
+        return repository.save(book);
+    }
+
+    @GetMapping("/{id}")
+    public Book get(@PathVariable String id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    @PutMapping("/{id}")
+    public Book update(@PathVariable String id, @RequestBody Book book) {
+        Book existing = repository.findById(id).orElseThrow();
+        existing.setTitle(book.getTitle());
+        existing.setAuthor(book.getAuthor());
+        existing.setDescription(book.getDescription());
+        return repository.save(existing);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable String id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/sample/library/BookRepository.java
+++ b/src/main/java/sample/library/BookRepository.java
@@ -1,0 +1,6 @@
+package sample.library;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface BookRepository extends MongoRepository<Book, String> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.data.mongodb.uri=mongodb://localhost:27017/bookdb

--- a/src/test/java/sample/library/BookControllerTests.java
+++ b/src/test/java/sample/library/BookControllerTests.java
@@ -1,0 +1,83 @@
+package sample.library;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(BookController.class)
+class BookControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BookRepository repository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void listBooks() throws Exception {
+        Book book = new Book("Title", "Author", "Desc");
+        given(repository.findAll()).willReturn(Collections.singletonList(book));
+
+        mockMvc.perform(get("/books"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].title").value("Title"));
+    }
+
+    @Test
+    void createBook() throws Exception {
+        Book book = new Book("Title", "Author", "Desc");
+        given(repository.save(any(Book.class))).willReturn(book);
+
+        mockMvc.perform(post("/books")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(book)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.author").value("Author"));
+    }
+
+    @Test
+    void getBook() throws Exception {
+        Book book = new Book("Title", "Author", "Desc");
+        given(repository.findById("1")).willReturn(Optional.of(book));
+
+        mockMvc.perform(get("/books/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.description").value("Desc"));
+    }
+
+    @Test
+    void updateBook() throws Exception {
+        Book existing = new Book("Title", "Author", "Desc");
+        given(repository.findById("1")).willReturn(Optional.of(existing));
+        given(repository.save(any(Book.class))).willReturn(existing);
+
+        Book update = new Book("New", "NewAuth", "NewDesc");
+        mockMvc.perform(put("/books/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(update)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("New"));
+    }
+
+    @Test
+    void deleteBook() throws Exception {
+        mockMvc.perform(delete("/books/1"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/sample/library/BookTests.java
+++ b/src/test/java/sample/library/BookTests.java
@@ -1,0 +1,22 @@
+package sample.library;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BookTests {
+    @Test
+    void bookProperties() {
+        Book book = new Book("Title", "Author", "Desc");
+        assertThat(book.getTitle()).isEqualTo("Title");
+        assertThat(book.getAuthor()).isEqualTo("Author");
+        assertThat(book.getDescription()).isEqualTo("Desc");
+
+        book.setTitle("t2");
+        book.setAuthor("a2");
+        book.setDescription("d2");
+
+        assertThat(book.getTitle()).isEqualTo("t2");
+        assertThat(book.getAuthor()).isEqualTo("a2");
+        assertThat(book.getDescription()).isEqualTo("d2");
+    }
+}

--- a/src/test/java/sample/war/WarApplicationResourceTests.java
+++ b/src/test/java/sample/war/WarApplicationResourceTests.java
@@ -1,42 +1,19 @@
-/*
- * Copyright 2012-2016 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package sample.war;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest
-public class WarApplicationResourceTests {
+class WarApplicationResourceTests {
 
-	// gh-6371
+    @Value("${demo.string.value}")
+    private String demoStringValue;
 
-	@Value("${demo.string.value}")
-	private String demoStringValue;
-
-	@Test
-	public void contextLoads() {
-		assertThat(this.demoStringValue).isEqualTo("demo");
-	}
-
+    @Test
+    void contextLoads() {
+        assertThat(this.demoStringValue).isEqualTo("demo");
+    }
 }


### PR DESCRIPTION
## Summary
- update to Spring Boot 3.2.5 and Java 21
- add `Book` domain object and CRUD controller backed by MongoDB
- provide MongoDB configuration
- update tests to JUnit 5
- add JaCoCo coverage rules and new tests for book API
- refresh README with usage instructions
- add Dockerfile and compose setup for local testing

## Testing
- `mvn --version`
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_6858a70a61ec8324adb41514ee512812