### PR TITLE
Add standard .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Maven build directories
+/target/
+
+# IntelliJ IDEA project files
+.idea/
+*.iml
+
+# Eclipse project files
+.project
+.classpath
+.settings/
+
+# Logs
+*.log
+
+# OS-specific files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- add a .gitignore file to filter Maven build outputs and IDE project files

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6858ab0c612c83248fbf6985aab8e243